### PR TITLE
develop

### DIFF
--- a/src/main/java/live/ioteatime/frontservice/controller/LoginController.java
+++ b/src/main/java/live/ioteatime/frontservice/controller/LoginController.java
@@ -5,7 +5,6 @@ import live.ioteatime.frontservice.dto.LoginRequest;
 import live.ioteatime.frontservice.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,15 +18,22 @@ import javax.servlet.http.HttpServletResponse;
 public class LoginController {
 
     private final UserAdaptor userAdaptor;
+    private final String ACCESS_TOKEN_KEY = "iotaot";
 
+    /**
+     * 로그인 요청을 처리합니다.
+     * @param loginRequest 사용자 입력 id, pw
+     * @param response
+     * @return 로그인 성공 시 메인 페이지로 리다이렉트
+     */
     @PostMapping
     public String login(@ModelAttribute LoginRequest loginRequest, HttpServletResponse response){
         LoginResponse loginResponse = userAdaptor.login(loginRequest).getBody();
 
         log.info("loginResponse: {} {}", loginResponse.getType(), loginResponse.getToken());
 
-        Cookie cookie = new Cookie(HttpHeaders.AUTHORIZATION, loginResponse.getType() + "-" + loginResponse.getToken());
-        cookie.setMaxAge(3600);
+        Cookie cookie = new Cookie(ACCESS_TOKEN_KEY, loginResponse.getToken());
+        cookie.setMaxAge(0);
         response.addCookie(cookie);
 
         return "redirect:/";

--- a/src/main/java/live/ioteatime/frontservice/controller/LoginController.java
+++ b/src/main/java/live/ioteatime/frontservice/controller/LoginController.java
@@ -33,7 +33,7 @@ public class LoginController {
         log.info("loginResponse: {} {}", loginResponse.getType(), loginResponse.getToken());
 
         Cookie cookie = new Cookie(ACCESS_TOKEN_KEY, loginResponse.getToken());
-        cookie.setMaxAge(0);
+        cookie.setMaxAge(3600);
         response.addCookie(cookie);
 
         return "redirect:/";


### PR DESCRIPTION
기존에는 브라우저 쿠키에 액세스 토큰을 저장할 때
"Authorization": "[토큰타입]-[토큰값]" 형식으로 저장했었지만, 보안상 위험하다고 판단하여
"iotaot" : "[토큰값]" 형식으로 저장하도록 수정하였습니다.