### PR TITLE
Fix/general

### DIFF
--- a/src/main/java/live/ioteatime/frontservice/adaptor/ElectricityAdaptor.java
+++ b/src/main/java/live/ioteatime/frontservice/adaptor/ElectricityAdaptor.java
@@ -62,7 +62,7 @@ public interface ElectricityAdaptor {
     @GetMapping("/api/hourly/electricities/total")
     ResponseEntity<List<PreciseElectricitiesDto>> getOneHourTotalElectricties(@RequestParam int organizationId);
 
-    /** todo 검색할 때 organizationId로 검색해야 할 것 같아요.
+    /**
      * 한달 예측값을 가져옵니다.
      * @param requestTime 검색할 시간을 RequestParam으로 받아옵니다.
      * @return (time, kwh) 리스트를 리턴합니다.
@@ -70,7 +70,8 @@ public interface ElectricityAdaptor {
     @GetMapping("/api/predicted")
     ResponseEntity<List<PreciseElectricitiesDto>> getMonthlyPredictedValues(
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            @RequestParam LocalDateTime requestTime);
+            @RequestParam LocalDateTime requestTime,
+            @RequestParam int organizationId);
 
     /**
      * 해당 조직이 한달 동안 사용한 총 전력량 리스트를 가져옵니다.

--- a/src/main/java/live/ioteatime/frontservice/config/FeignClientConfig.java
+++ b/src/main/java/live/ioteatime/frontservice/config/FeignClientConfig.java
@@ -20,9 +20,10 @@ import javax.servlet.http.HttpServletRequest;
 public class FeignClientConfig {
 
     /**
+     * OpenFeign으로 게이트웨이에 요청을 보내는 경우, 액세스 토큰을 요청 헤더에 저장하기 위한 인터셉터입니다.
      * 로그인 하지 않은 유저가 엑세스 토큰 없이 회원 가입 페이지와 로그인 페이지에 접속할 수 있도록 하고,
      * 회원 가입과 로그인을 제외한 요청이 들어올 경우 엑세스 토큰이 없다면 UnauthorizedAccessException을 리턴하고,
-     * 토큰이 있다면 헤더에 토큰 정보를 저장 합니다.
+     * 브라우저 쿠키에 토큰이 있다면 요청 헤더에 토큰 정보를 저장 합니다.
      *
      * @param cookieUtil 엑세스 토큰을 가져오기위해 사용 됩니다.
      * @return 로그인이나 회원 가입 요청이라면 해당 페이지를, 그 외의 요청에서 토큰이 없는 경우 에러를 던집니다.
@@ -30,14 +31,11 @@ public class FeignClientConfig {
     @Bean
     public RequestInterceptor requestTokenBearerInterceptor(CookieUtil cookieUtil) {
         return requestTemplate -> {
-
             HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
 
             String url = requestTemplate.url();
             log.error("{} {}", url, request.getMethod());
-            if (url.equals("/auth/login") ||
-                    (request.getMethod().equals("GET") && (url.equals("/users/update-user") || url.equals("/users/change-password"))) ||
-                    (url.equals("/api/users") && request.getMethod().equals("POST"))
+            if (url.equals("/auth/login") || (url.equals("/api/users") && request.getMethod().equals("POST"))
             ) {
                 return;
             }
@@ -47,8 +45,6 @@ public class FeignClientConfig {
             }
             requestTemplate.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
             log.info("AccessToken applied for request: {}", requestTemplate.headers().get("Authorization"));
-
         };
     }
 }
-

--- a/src/main/java/live/ioteatime/frontservice/controller/IndexController.java
+++ b/src/main/java/live/ioteatime/frontservice/controller/IndexController.java
@@ -91,7 +91,8 @@ public class IndexController {
     @GetMapping("/monthly-predict")
     @ResponseBody
     public List<PreciseElectricitiesDto> getMontlyPredictedElectricities() {
-        return electricityAdaptor.getMonthlyPredictedValues(LocalDateTime.now()).getBody();
+        int organizationId = userAdaptor.getUser().getBody().getOrganization().getId();
+        return electricityAdaptor.getMonthlyPredictedValues(LocalDateTime.now(), organizationId).getBody();
     }
 
     @GetMapping("/kwh")

--- a/src/main/java/live/ioteatime/frontservice/dto/response/BudgetHistoryResponse.java
+++ b/src/main/java/live/ioteatime/frontservice/dto/response/BudgetHistoryResponse.java
@@ -1,5 +1,6 @@
 package live.ioteatime.frontservice.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 public class BudgetHistoryResponse {
     private int id;
     @JsonProperty("change_time")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime changeTime;
     private long budget;
 }


### PR DESCRIPTION
## 1. Dto에 `@JsonFormat` 추가
api-service에서 BudgetHistoryDto가 클래스 dto로 바뀌면서 `@JsonFormat` 어노테이션이 추가되었습니다.
(참고: https://github.com/nhnacademy-aiot1-5/api-service/pull/95)

프론트 서비스에서도 동일한 패턴의 문자열로 받아서 localDateTime에 바인딩할 수 있도록 동일한 어노테이션을 추가해주었습니다.

## 2. 한 달 예측값 검색 파라미터에 조직아이디 추가
조직의 총 예측값을 요청하는 api이기 때문에 파라미터로 조직아이디를 받아야할 것 같아서 추가했습니다.

## 3. FeignConfig 설정 변경
로그인, 회원가입 제외하고 모든 페이지에서 엑세스 토큰을 체크하도록 변경하였습니다.