### PR TITLE
대시보드 구조 변경 및 그래프 추가

### DIFF
--- a/src/main/java/live/ioteatime/frontservice/controller/IndexController.java
+++ b/src/main/java/live/ioteatime/frontservice/controller/IndexController.java
@@ -105,4 +105,16 @@ public class IndexController {
 
         return new KwhDto(lastMonthKwh, thisMonthKwh, todayKwh, yesterdayKwh);
     }
+
+    @GetMapping("/bill")
+    @ResponseBody
+    public List<DailyElectricityDto> getCumulativeBills() {
+        return  electricityService.getCumulativeBills();
+    }
+
+    @GetMapping("/bill-predict")
+    @ResponseBody
+    public List<PreciseElectricitiesDto> getCumulativeBillPredictions() {
+        return electricityService.getCumulativeBillPredictions();
+    }
 }

--- a/src/main/java/live/ioteatime/frontservice/dto/response/PreciseElectricitiesDto.java
+++ b/src/main/java/live/ioteatime/frontservice/dto/response/PreciseElectricitiesDto.java
@@ -12,4 +12,5 @@ public class PreciseElectricitiesDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime time;
     private Double kwh;
+    private Long bill;
 }

--- a/src/main/java/live/ioteatime/frontservice/service/ElectricityService.java
+++ b/src/main/java/live/ioteatime/frontservice/service/ElectricityService.java
@@ -2,11 +2,15 @@ package live.ioteatime.frontservice.service;
 
 import live.ioteatime.frontservice.adaptor.ElectricityAdaptor;
 import live.ioteatime.frontservice.adaptor.UserAdaptor;
+import live.ioteatime.frontservice.dto.DailyElectricityDto;
 import live.ioteatime.frontservice.dto.RealtimeElectricityResponseDto;
+import live.ioteatime.frontservice.dto.response.PreciseElectricitiesDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,7 +30,35 @@ public class ElectricityService {
                 .sorted(Comparator.comparing(RealtimeElectricityResponseDto::getW).reversed())
                 .limit(10)
                 .collect(Collectors.toList());
-
         return response;
+    }
+
+    public List<DailyElectricityDto> getCumulativeBills() {
+        LocalDateTime time = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+        List<DailyElectricityDto> electricityDtoList = userAdaptor.getDailyElectricities(time,-1).getBody();
+        Long bill = 0L;
+        for(DailyElectricityDto e : electricityDtoList) {
+            bill += e.getBill();
+            e.setBill(bill);
+        }
+        return electricityDtoList;
+    }
+
+    public List<PreciseElectricitiesDto> getCumulativeBillPredictions() {
+        LocalDateTime time = LocalDateTime.now().withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+        List<PreciseElectricitiesDto> electricityDtoList = electricityAdaptor
+                .getMonthlyPredictedValues(time,-1).getBody();
+
+        Long bill = 0L;
+        LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+        List<PreciseElectricitiesDto> result = new ArrayList<>();
+        for(PreciseElectricitiesDto e : electricityDtoList) {
+            bill += e.getBill();
+            e.setBill(bill);
+            if(e.getTime().isEqual(today) || e.getTime().isAfter(today)) {
+                result.add(e);
+            }
+        }
+        return electricityDtoList;
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -9,7 +9,22 @@
     <link rel="stylesheet" href="https://fastly.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <script src="https://fastly.jsdelivr.net/npm/apexcharts"></script>
     <script src="https://fastly.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <style>
+        .why {
+            width: 85%;
+            margin-right: 0;
+            margin-left: 0;
+            margin: auto;
+        }
+        /*@media (min-width: 992px) {*/
+        /*    .container-fluid {*/
+        /*        width: 90%;*/
+        /*        max-width: 90%;*/
+        /*    }*/
+        /*}*/
+    </style>
 </head>
+
 
 <body>
 <div class="page-wrapper" id="main-wrapper" data-layout="vertical" data-navbarbg="skin6" data-sidebartype="full"
@@ -17,13 +32,13 @@
     <th:block th:replace="side-bar :: sidebar"></th:block>
 
     <div class="body-wrapper">
-        <th:block th:replace="header :: header"></th:block>
+<!--        <th:block th:replace="header :: header"></th:block>-->
 
-        <div class="container-fluid">
+        <div class="why">
             <div class="card-body position-relative">
+                <!--첫번째 row-->
                 <div class="row">
                     <div class="col-lg-8 d-flex align-items-strech">
-                        <div class="row">
                             <div class="card w-100 mb-2">
                                 <div class="card-body">
                                     <div class="d-sm-flex d-block align-items-center justify-content-between mb-9">
@@ -52,38 +67,46 @@
                                         </div>
                                     </div>
                                 </div>
-                            </div>
 
                             <div class="card w-100">
-                                <div class="card-body">
-                                    <div class="d-sm-flex d-block align-items-center justify-content-between mb-3">
-                                        <div class="overflow-hidden me-6">
-                                            <h5 class="fw-semibold">실시간 전력 사용량</h5>
-                                        </div>
-                                    </div>
-                                    <div class="row">
+<!--                                <div class="card-body">-->
+<!--                                    <div class="d-sm-flex d-block align-items-center justify-content-between mb-3">-->
+<!--                                        <div class="overflow-hidden me-6">-->
+<!--                                            <h5 class="fw-semibold">실시간 전력 사용량</h5>-->
+<!--                                        </div>-->
+<!--                                    </div>-->
+<!--                                    <div class="row">-->
 
-                                        <div class="col-lg-6">
+<!--                                        <div class="col-lg-4">-->
 
-                                            <div class="d-sm-flex d-block align-items-center justify-content-between">
-                                                <div id="realtime-total"></div>
-                                                <div id="new" style="flex:1"></div>
-                                            </div>
-                                        </div>
+<!--                                            <div class="d-sm-flex d-block align-items-center justify-content-between">-->
+<!--                                                <div id="realtime-total"></div>-->
+<!--                                                <div id="new" style="flex:1"></div>-->
+<!--                                            </div>-->
+<!--                                        </div>-->
 
-                                        <div class="col-lg-6">
-                                            <div class="d-sm-flex d-block align-items-center justify-content-between">
-                                                <div id="daily-predict"></div>
-                                            </div>
-                                        </div>
-                                    </div>
+<!--                                        <div class="col-lg-4">-->
+<!--                                            <div class="d-sm-flex d-block align-items-center justify-content-between">-->
+<!--                                                <div id="daily-predict"></div>-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+
+<!--                                        <div class="col-lg-4">-->
+<!--                                            <div class="d-sm-flex d-block align-items-center justify-content-between">-->
+<!--                                                <div id="cumulative-bill"></div>-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+
+<!--                                    </div>-->
                                 </div>
                             </div>
-                        </div>
-                    </div>
+
+
+                </div>
+
+                    <!-- 요금 게이지 바 -->
                     <div class="col-lg-4">
-                        <!-- 요금 게이지 바 -->
-                        <div class="col-lg-12">
+                        <div class="col">
                             <div class="card overflow-hidden mb-2">
                                 <div class="card-body p-3">
                                     <h5 class="card-title mb-9 fw-semibold">테스트 요금</h5>
@@ -214,129 +237,150 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="row">
-                            <div class="d-flex justify-content-center">
-                                <div class="col-lg-4 ">
-                                    <div class="card overflow-hidden">
-                                        <div class="card-body p-3">
-                                            <h5 class="card-title mb-9 fw-semibold">사용 요금</h5>
-                                            <div class="row align-items-center">
-                                                <div class="col-20">
-                                                    <h2 class="fs-2 fw-semibold mb-3 text-nowrap" id="bill">아무도 날 막을 수 없으셈 ㅋㅋ</h2>
-                                                    <div class="d-flex align-items-center mb-3">
-                                                        <i class="bi bi-arrow-up-left-circle-fill text-success me-1"
-                                                           style="font-size: 0.5rem;"></i>
-                                                        <p class="me-1 fs-2 mb-0" id="bill-percentage">+9%</p>
-                                                        <p class="fs-1 mb-0">1일 전</p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-4" id="update-fee" th:data-role="${userInfo.role}"
-                                     onclick="checkRoleAndOpenModal()">
-                                    <div class="card overflow-hidden">
-                                        <div class="card-body cursor-pointer p-3" >
-                                            <h5 class="card-title mb-9 fw-semibold">설정 요금</h5>
-                                            <div class="row align-items-center">
-                                                <div class="col-20">
-                                                    <h2 class="fs-2 fw-semibold mb-3 text-nowrap"
-                                                        th:text="'₩ '+${#numbers.formatInteger(budget.electricityBudget, 0, 'COMMA')}">
-                                                        현재 설정 요금</h2>
-                                                    <div class="d-flex align-items-center mb-3" th:if="${userInfo.role.name() == 'ADMIN'}">
-                                                        <p class="me-1 fs-2 mb-0">클릭 시</p>
-                                                        <p class="fs-2 mb-0">수정</p>
-                                                    </div>
-                                                    <div class="d-flex align-items-center mb-3" th:unless="${userInfo.role.name() == 'ADMIN'}">
-                                                        <p class="me-1 fs-2 mb-0">🌱🌱</p>
-                                                        <p class="fs-2 mb-0">🌱🌱</p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-4 ">
-                                    <div class="card overflow-hidden">
-                                        <div class="card-body p-3">
-                                            <h5 class="card-title mb-9 fw-semibold">요금 차액</h5>
-                                            <div class="row align-items-center">
-                                                <div class="col-20">
-                                                    <h2 class="fs-2 fw-semibold mb-3 text-nowrap"
-                                                        id="remain-budget">1972년 11월 21일 김두한은 오렌지병으로 쓰러졌다.</h2>
-                                                    <div class="d-flex align-items-center mb-3">
-                                                        <i class="bi bi-arrow-up-left-circle-fill text-success me-1"
-                                                           style="font-size: 0.5rem;"></i>
-                                                        <p class="me-1 fs-2 mb-0" id="remain-budget-percentage">
-                                                            남은</p>
-                                                        <p class="fs-2 mb-0"> 금액</p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
+                    </div>
+            </div>
+
+
+            <div class="card-body position-relative">
+                <div class="card w-100">
+                    <div class="card-body">
+                        <div class="d-sm-flex d-block align-items-center justify-content-between mb-3">
+                            <div class="overflow-hidden me-6">
+                                <h5 class="fw-semibold">실시간 전력 사용량</h5>
                             </div>
                         </div>
+            <div class="row">
+
+
+                <div class="col-lg-4">
+                    <div>
+                        <div id="daily-predict"></div>
                     </div>
                 </div>
+
+                <div class="col-lg-4">
+                    <div id="realtimeChart"></div>
+                </div>
+
+                <div class="col-lg-4">
+                    <div>
+                        <div id="realtime-total"></div>
+<!--                        <div id="new" style="flex:1"></div>-->
+                    </div>
+                </div>
+
             </div>
-            <div class="row">
-                <div class="col-lg-9 d-flex align-items-strech">
+            </div>
+                </div>
+
+                <div class="card-body position-relative">
                     <div class="card w-100">
                         <div class="card-body">
-                            <div class="d-sm-flex d-block align-items-center justify-content-between mb-9">
-                                <div class="mb-3 mb-sm-0">
-                                    <h5 class="card-title fw-semibold">실시간 전력량</h5>
+            <div class="row">
+
+                <div class="col-8">
+                    <div>
+                        <div id="cumulative-bill"></div>
+                    </div>
+                </div>
+
+
+
+                <div class="col-4">
+                    <div class="row">
+
+                        <div class="d-flex justify-content-center">
+                            <div class="col-6 ">
+                                <div class="card overflow-hidden">
+                                    <div class="card-body p-3">
+                                        <h5>사용 요금</h5>
+                                        <div class="row align-items-center">
+                                            <div class="col-20">
+                                                <h2 class="fs-2 fw-semibold mb-3 text-nowrap" id="bill">아무도 날 막을 수 없으셈 ㅋㅋ</h2>
+                                                <div class="d-flex align-items-center mb-3">
+                                                    <i class="bi bi-arrow-up-left-circle-fill text-success me-1"
+                                                       style="font-size: 0.5rem;"></i>
+                                                    <p class="me-1 fs-2 mb-0" id="bill-percentage">+9%</p>
+                                                    <p class="fs-1 mb-0">1일 전</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                            <div id="realtimeChart"></div>
+                            <div class="col-6" id="update-fee" th:data-role="${userInfo.role}"
+                                 onclick="checkRoleAndOpenModal()">
+                                <div class="card overflow-hidden">
+                                    <div class="card-body cursor-pointer p-3" >
+                                        <h5>설정 요금</h5>
+                                        <div class="row align-items-center">
+                                            <div class="col-20">
+                                                <h2 class="fs-2 fw-semibold mb-3 text-nowrap"
+                                                    th:text="'₩ '+${#numbers.formatInteger(budget.electricityBudget, 0, 'COMMA')}">
+                                                    현재 설정 요금</h2>
+                                                <div class="d-flex align-items-center mb-3" th:if="${userInfo.role.name() == 'ADMIN'}">
+                                                    <p class="me-1 fs-2 mb-0">클릭 시</p>
+                                                    <p class="fs-2 mb-0">수정</p>
+                                                </div>
+                                                <div class="d-flex align-items-center mb-3" th:unless="${userInfo.role.name() == 'ADMIN'}">
+                                                    <p class="me-1 fs-2 mb-0">🌱🌱</p>
+                                                    <p class="fs-2 mb-0">🌱🌱</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="col-md-3">
+
+                        <div class="row">
+                            <div class="d-flex justify-content-center">
+                            <div class="col-lg-6 ">
+                                <div class="card overflow-hidden">
+                                    <div class="card-body p-3">
+                                        <h5>전일<i class="ti ti-bolt fs-6 text-warning"></i></h5>
+                                        <h4 id="yesterdayKwh">-</h4>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-lg-6 ">
+                                <div class="card overflow-hidden">
+                                    <div class="card-body p-3">
+                                        <h5>금일<i class="ti ti-bolt fs-6 text-warning"></i></h5>
+                                        <h4 id="todayKwh">-</h4>
+                                    </div>
+                                </div>
+                            </div>
+                            </div>
+                        </div>
+
                     <div class="row">
-                        <div class="card">
-                            <div class="card-body">
-                                <h5>
-                                    전일 사용 전력량
-                                    <i class="ti ti-bolt fs-6 text-warning"></i>
-                                </h5>
-                                <h4 id="yesterdayKwh">67.12 kWh</h4>
+                        <div class="d-flex justify-content-center">
+                            <div class="col-lg-6 ">
+                                <div class="card overflow-hidden">
+                                    <div class="card-body p-3">
+                                        <h5>전월<i class="ti ti-bolt fs-6 text-warning"></i></h5>
+                                        <h4 id="lastMonth">-</h4>
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="card">
-                            <div class="card-body">
-                                <h5>
-                                    금일 사용 전력량
-                                    <i class="ti ti-bolt fs-6 text-warning"></i>
-                                </h5>
-                                <h4 id="todayKwh">54.50 kWh</h4>
-                            </div>
-                        </div>
-                        <div class="card">
-                            <div class="card-body">
-                                <h5>
-                                    전월 사용 전력량
-                                    <i class="ti ti-bolt fs-6 text-warning"></i>
-                                </h5>
-                                <h4 id="lastMonth">5,596.70 kWh</h4>
-                            </div>
-                        </div>
-                        <div class="card">
-                            <div class="card-body">
-                                <h5>
-                                    금월 사용 전력량
-                                    <i class="ti ti-bolt fs-6 text-warning"></i>
-                                </h5>
-                                <h4 id="thisMonthKwh">1,257.60 kWh</h4>
+                            <div class="col-lg-6 ">
+                                <div class="card overflow-hidden">
+                                    <div class="card-body p-3">
+                                        <h5>금월<i class="ti ti-bolt fs-6 text-warning"></i></h5>
+                                        <h4 id="thisMonthKwh">-</h4>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
             </div>
         </div>
+
+                        </div></div></div>
+
+
     </div>
 </div>
 
@@ -377,11 +421,37 @@
         </div>
     </div>
 </div>
+
+            <!-- 요금 차액. 위치 옮길예쩡-->
+            <div class="col-lg-4 ">
+                <div class="card overflow-hidden">
+                    <div class="card-body p-3">
+                        <h5 class="card-title mb-9 fw-semibold">요금 차액</h5>
+                        <div class="row align-items-center">
+                            <div class="col-20">
+                                <h2 class="fs-2 fw-semibold mb-3 text-nowrap"
+                                    id="remain-budget">1972년 11월 21일 김두한은 오렌지병으로 쓰러졌다.</h2>
+                                <div class="d-flex align-items-center mb-3">
+                                    <i class="bi bi-arrow-up-left-circle-fill text-success me-1"
+                                       style="font-size: 0.5rem;"></i>
+                                    <p class="me-1 fs-2 mb-0" id="remain-budget-percentage">
+                                        남은</p>
+                                    <p class="fs-2 mb-0"> 금액</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>
+</body>
 <script>
     let options = {
         chart: {
-            type: 'bar',
-            height: 250
+            type: 'bar'
         },
         plotOptions: {
             bar: {
@@ -482,7 +552,6 @@
         }],
         chart: {
             id: 'realtime',
-            height: 350,
             type: 'bar',
             zoom: {
                 enabled: false
@@ -619,7 +688,6 @@
                     name: 'kwh'
                 }],
                 chart: {
-                    height: 350,
                     type: 'line',
                 },
                 forecastDataPoints: {
@@ -667,6 +735,104 @@
         initdailyPredictChart();
     });
 </script>
-</body>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const fetchCurrentMonthData = async () => {
+            try {
+                const response = await fetch('/bill');
+                if (!response.ok) throw new Error('Failed to fetch current month data');
+                return response.json();
+            } catch (error) {
+                console.error('Error fetching current month data:', error);
+                return [];
+            }
+        };
+
+        const fetchPredictedData = async () => {
+            try {
+                const response = await fetch('/bill-predict');
+                if (!response.ok) throw new Error('Failed to fetch predicted data');
+                return response.json();
+            } catch (error) {
+                console.error('Error fetching predicted data:', error);
+                return [];
+            }
+        };
+
+        const prepareChartData = (data) => {
+            return data.map(item => ({
+                x: new Date(item.time).getTime(),
+                y: item.bill
+            }));
+        };
+
+        const initdailyPredictChart = async () => {
+            const currentMonthData = await fetchCurrentMonthData();
+            const predictedData = await fetchPredictedData();
+
+            const fullData = prepareChartData(currentMonthData).concat(prepareChartData(predictedData));
+            fullData.sort((a, b) => a.x - b.x);
+
+            const today = new Date();
+            const endOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+            const forecastCount = endOfMonth.getDate() - today.getDate() - 1;
+
+            const chartOptions = {
+                series: [{
+                    data: fullData,
+                    name: 'kwh'
+                }],
+                chart: {
+                    // height: 350,
+                    // width: '100%',
+                    type: 'line',
+                },
+                forecastDataPoints: {
+                    count: forecastCount
+                },
+                stroke: {
+                    width: 5,
+                    curve: 'smooth'
+                },
+                xaxis: {
+                    type: 'datetime',
+                    tickAmount: 10,
+                    labels: {
+                        formatter: function (value, timestamp) {
+                            return new Date(timestamp).toLocaleDateString('en-US', {month: 'short', day: '2-digit'});
+                        }
+                    }
+                },
+                title: {
+                    text: '이번 달 소비 요금',
+                    align: 'left',
+                    style: {
+                        fontSize: "14px",
+                        color: '#666'
+                    }
+                },
+                fill: {
+                    type: 'gradient',
+                    gradient: {
+                        shade: 'dark',
+                        gradientToColors: ['#FDD835'],
+                        shadeIntensity: 1,
+                        type: 'horizontal',
+                        opacityFrom: 1,
+                        opacityTo: 1,
+                        stops: [0, 100, 100, 100]
+                    },
+                }
+            };
+
+            var dailyPredictChart = new ApexCharts(document.querySelector("#cumulative-bill"), chartOptions);
+            dailyPredictChart.render();
+        };
+
+        initdailyPredictChart();
+    });
+</script>
+<!--</body>-->
 
 </html>


### PR DESCRIPTION
## 1. 누적 요금 그래프 추가
- 대시보드에 누적 요금 그래프를 추가하였습니다.
- 누적 요금 그래프에는 이번 달 누적 요금 데이터가 표시됩니다.
    - 1일 ~ 요청일(오늘) : 실제 사용 금액
    - 요청일 다음날(내일) ~ 말일 : 예측 사용 금액
## 2. 대시보드 배치 변경
- 더 보기 좋게 전체적인 배치를 변경하였습니다.
![image](https://github.com/nhnacademy-aiot1-5/front-service/assets/124178635/92a7d64c-cc7c-4333-9540-9172c9a1c83c)
