### PR TITLE
fix : 대시보드 실선그래프 데이터 개수 변경

### DIFF
--- a/src/main/java/live/ioteatime/frontservice/service/ElectricityService.java
+++ b/src/main/java/live/ioteatime/frontservice/service/ElectricityService.java
@@ -44,14 +44,16 @@ public class ElectricityService {
         LocalDateTime time = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
         List<DailyElectricityDto> electricityDtoList = userAdaptor.getDailyElectricities(time,-1).getBody();
         Long bill = 0L;
+        List<DailyElectricityDto> cumulativeBillsUntilToday = new ArrayList<>();
         for(DailyElectricityDto e : electricityDtoList) {
             bill += e.getBill();
             e.setBill(bill);
+            if (e.getTime().isAfter(time)) {
+                break;
+            }
+            cumulativeBillsUntilToday.add(e);
         }
-        if (electricityDtoList.size() > 1) {
-            electricityDtoList.remove(electricityDtoList.size() - 1);
-        }
-        return electricityDtoList;
+        return cumulativeBillsUntilToday;
     }
 
     public List<PreciseElectricitiesDto> getCumulativeBillPredictions() {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -316,8 +316,6 @@
                                         </div>
                                     </div>
                                 </div>
-
-                                <!--                                </div>-->
                             </div>
 
 
@@ -461,7 +459,7 @@
                     shade: 'light',
                     type: "horizontal",
                     shadeIntensity: 0.5,
-                    gradientToColors: ['#F17674'], // optional, if not defined - uses the shades of same color in series
+                    gradientToColors: ['#F17674'],
                     inverseColors: true,
                     opacityFrom: 1,
                     opacityTo: 0.8,
@@ -680,16 +678,14 @@
                 }));
             };
 
-            const initdailyPredictChart = async () => {
+            const initDailyPredictChart = async () => {
                 const currentMonthData = await fetchCurrentMonthData();
                 const predictedData = await fetchPredictedData();
 
                 const fullData = prepareChartData(currentMonthData).concat(prepareChartData(predictedData));
                 fullData.sort((a, b) => a.x - b.x);
 
-                const today = new Date();
-                const endOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
-                const forecastCount = endOfMonth.getDate() - today.getDate() - 1;
+                const forecastCount = predictedData.length;
 
                 const chartOptions = {
                     series: [{
@@ -745,7 +741,7 @@
                 dailyPredictChart.render();
             };
 
-            initdailyPredictChart();
+            initDailyPredictChart();
         });
     </script>
     <script>
@@ -773,6 +769,7 @@
             };
 
             const prepareChartData = (currentMonthData, predictedData) => {
+
                 const current = currentMonthData.map(item => ({
                     x: new Date(item.time).getTime(),
                     y: item.bill
@@ -812,9 +809,7 @@
             const fullData = prepareChartData(currentMonthData, predictedData);
             fullData.sort((a, b) => a.x - b.x);
 
-            const today = new Date();
-            const endOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
-            const forecastCount = endOfMonth.getDate() - today.getDate() - 1;
+            const forecastCount = predictedData.length;
 
             const maxVal = Math.max(budget+1000, fullData[fullData.length-1].y);
             const yMax = Math.ceil(maxVal / 5000) * 5000;
@@ -884,7 +879,6 @@
                         }
                     }]
                 }
-
                 ,
                 fill: {
                     type: 'gradient',
@@ -892,7 +886,7 @@
                         shade: 'light',
                         type: "vertical",
                         shadeIntensity: 0.5,
-                        gradientToColors: ['#846EF4'], // optional, if not defined - uses the shades of same color in series
+                        gradientToColors: ['#846EF4'],
                         inverseColors: true,
                         opacityFrom: 1,
                         opacityTo: 0.8,


### PR DESCRIPTION
실선 그래프에는
요청일 기준 월초부터 요청일까지의 데이터가 표시되어야 하는데,
요청일 기준 월초부터 월말까지의 데이터가 모두 표시되는 이슈가 있었습니다.

수정완