### PR TITLE
fix : 비밀번호 변경 안 되는 이슈 해결

### DIFF
--- a/src/main/java/live/ioteatime/frontservice/config/FeignClientConfig.java
+++ b/src/main/java/live/ioteatime/frontservice/config/FeignClientConfig.java
@@ -35,8 +35,7 @@ public class FeignClientConfig {
 
             String url = requestTemplate.url();
             log.error("{} {}", url, request.getMethod());
-            if (url.equals("/auth/login") || (url.equals("/api/users") && request.getMethod().equals("POST"))
-            ) {
+            if (url.equals("/auth/login")) {
                 return;
             }
             String accessToken = cookieUtil.getCookieValue(request, "iotaot");

--- a/src/main/java/live/ioteatime/frontservice/controller/UserController.java
+++ b/src/main/java/live/ioteatime/frontservice/controller/UserController.java
@@ -67,9 +67,15 @@ public class UserController {
         return "redirect:/mypage";
     }
 
+    @GetMapping("/change-password")
+    public String changePasswordPage() {
+        return "authentication/change-password";
+    }
+
     @PostMapping("/change-password")
-    public String changePassword(HttpServletRequest request, RedirectAttributes redirectAttributes,
-                                 @Valid @ModelAttribute ChangePasswordRequest changePasswordRequest, BindingResult bindingResult) {
+    public String changePassword(RedirectAttributes redirectAttributes,
+                                 @Valid @ModelAttribute ChangePasswordRequest changePasswordRequest,
+                                 BindingResult bindingResult) {
         if (bindingResult.hasFieldErrors()) {
             redirectAttributes.addFlashAttribute("message", "모든 항목을 입력해주세요.");
             return "redirect:/change-password";
@@ -86,10 +92,5 @@ public class UserController {
         }
         redirectAttributes.addFlashAttribute("message", "비밀번호 변경이 완료되었습니다.");
         return "redirect:/mypage";
-    }
-
-    @GetMapping("/change-password")
-    public String changePasswordPage() {
-        return "authentication/change-password";
     }
 }

--- a/src/main/java/live/ioteatime/frontservice/interceptor/UserInfoInterceptor.java
+++ b/src/main/java/live/ioteatime/frontservice/interceptor/UserInfoInterceptor.java
@@ -42,7 +42,6 @@ public class UserInfoInterceptor implements HandlerInterceptor {
             throws Exception {
 
         if (!request.getMethod().equalsIgnoreCase("GET") || model == null) return;
-        log.info("interceptor 실행 됨");
         GetUserResponse userInfo = userAdaptor.getUser().getBody();
         if (userInfo == null) {
             throw new IllegalStateException();

--- a/src/main/resources/templates/authentication/change-password.html
+++ b/src/main/resources/templates/authentication/change-password.html
@@ -7,7 +7,8 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-<div class="page-wrapper" id="main-wrapper" data-layout="vertical" data-navbarbg="skin6" data-sidebartype="full" data-sidebar-position="fixed" data-header-position="fixed">
+<div class="page-wrapper" id="main-wrapper" data-layout="vertical" data-navbarbg="skin6" data-sidebartype="full"
+     data-sidebar-position="fixed" data-header-position="fixed">
     <!-- Sidebar Start -->
     <th:block th:replace="side-bar :: sidebar"></th:block>
     <!--  Sidebar End -->
@@ -16,33 +17,38 @@
         <!--  Header Start -->
         <th:block th:replace="header :: header"></th:block>
         <div class="container-fluid">
-    <div class="body-wrapper">
+            <div class="body-wrapper">
 
-        <div th:if="${message}" class="alert alert-danger" role="alert" style="text-align: center">
-            <p th:text="${message}"></p>
-        </div>
+                <div th:if="${message}" class="alert alert-danger" role="alert" style="text-align: center">
+                    <p th:text="${message}"></p>
+                </div>
 
-        <div class="container-fluid">
-            <div class="row">
-                <div class="col-md-6 mb-4">
-                    <div class="rounded-lg border bg-white text-dark shadow-sm">
-                        <div class="p-4">
-                            <h2 class="text-lg fw-bold">비밀번호 변경</h2>
-                            <form method="post" action="/change-password">
-                                <div class="mb-3">
-                                    <label for="currentPassword" class="form-label fw-semibold">기존 비밀번호</label>
-                                    <input type="password" class="form-control" id="currentPassword" name="currentPassword" required>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-md-6 mb-4">
+                            <div class="rounded-lg border bg-white text-dark shadow-sm">
+                                <div class="p-4">
+                                    <h2 class="text-lg fw-bold">비밀번호 변경</h2>
+                                    <form method="post" action="/change-password">
+                                        <div class="mb-3">
+                                            <label for="currentPassword" class="form-label fw-semibold">기존 비밀번호</label>
+                                            <input type="password" class="form-control" id="currentPassword"
+                                                   name="currentPassword" required>
+                                        </div>
+                                        <div class="mb-3">
+                                            <label for="newPassword" class="form-label fw-semibold">새 비밀번호</label>
+                                            <input type="password" class="form-control" id="newPassword"
+                                                   name="newPassword" required>
+                                        </div>
+                                        <div class="mb-3">
+                                            <label for="passwordCheck" class="form-label fw-semibold">새 비밀번호 확인</label>
+                                            <input type="password" class="form-control" id="passwordCheck"
+                                                   name="passwordCheck" required>
+                                        </div>
+                                        <button type="submit" class="btn btn-primary" style="width: 100%;">저장</button>
+                                    </form>
                                 </div>
-                                <div class="mb-3">
-                                    <label for="newPassword" class="form-label fw-semibold">새 비밀번호</label>
-                                    <input type="password" class="form-control" id="newPassword" name="newPassword" required>
-                                </div>
-                                <div class="mb-3">
-                                    <label for="passwordCheck" class="form-label fw-semibold">새 비밀번호 확인</label>
-                                    <input type="password" class="form-control" id="passwordCheck" name="passwordCheck" required>
-                                </div>
-                                <button type="submit" class="btn btn-primary" style="width: 100%;">저장</button>
-                            </form>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -51,6 +57,5 @@
     </div>
 </div>
 
-<script src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
비밀번호 변경 요청시 401 Unauthorized 응답이 돌아오는 이슈가 있었습니다.

디버깅 결과 헤더에 access token이 담기지 않아서 api-service로 요청이 전달되지 않는 것을 확인하였습니다.
이슈 원인은 FeignInterceptor에서 `POST /api/users` 요청에 대해서는 
헤더에 엑세스 토큰을 넣지 않도록 설정되어 있었기 때문이었습니다.

비밀번호 변경 요청에 대해서도 헤더에 액세스 토큰을 넣도록 수정하였습니다.

